### PR TITLE
V2 backport: 2243

### DIFF
--- a/src/ImageSharp/Formats/Webp/WebpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Webp/WebpDecoderCore.cs
@@ -277,7 +277,9 @@ namespace SixLabors.ImageSharp.Formats.Webp
                 }
                 else
                 {
-                    WebpThrowHelper.ThrowImageFormatException("Unexpected chunk followed VP8X header");
+                    // Ignore unknown chunks.
+                    uint chunkSize = this.ReadChunkSize();
+                    this.currentStream.Skip((int)chunkSize);
                 }
             }
 

--- a/tests/ImageSharp.Tests/Formats/WebP/WebpDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/WebP/WebpDecoderTests.cs
@@ -358,6 +358,17 @@ namespace SixLabors.ImageSharp.Tests.Formats.Webp
             }
         }
 
+        // https://github.com/SixLabors/ImageSharp/issues/2243
+        [Theory]
+        [WithFile(Lossy.Issue2243, PixelTypes.Rgba32)]
+        public void WebpDecoder_CanDecode_Issue2243<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using Image<TPixel> image = provider.GetImage(WebpDecoder);
+            image.DebugSave(provider);
+            image.CompareToOriginal(provider, ReferenceDecoder);
+        }
+
         [Theory]
         [WithFile(Lossless.LossLessCorruptImage3, PixelTypes.Rgba32)]
         public void WebpDecoder_ThrowImageFormatException_OnInvalidImages<TPixel>(TestImageProvider<TPixel> provider)

--- a/tests/ImageSharp.Tests/TestImages.cs
+++ b/tests/ImageSharp.Tests/TestImages.cs
@@ -726,6 +726,7 @@ namespace SixLabors.ImageSharp.Tests
 
                 // Issues
                 public const string Issue1594 = "Webp/issues/Issue1594.webp";
+                public const string Issue2243 = "Webp/issues/Issue2243.webp";
             }
         }
 

--- a/tests/Images/Input/Webp/issues/Issue2243.webp
+++ b/tests/Images/Input/Webp/issues/Issue2243.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1aae55fae66f3f9469ad5e28eb8134a04b1c5d746acf0a4a19d0f63ca0581cd
+size 55068


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Backport SixLabors/ImageSharp#2243